### PR TITLE
ci: add gitleaks secret scanning

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,33 @@
+name: gitleaks
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: gitleaks-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2.3.9
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Adds `gitleaks/gitleaks-action@v2.3.9` as a CI job on `pull_request` and `push` to main.

**VerdIQ is a public repo** — any leaked secret would be immediately scraped by bots. This is the highest-value repo for secret scanning.

## Scan scope
Scans only the PR diff / push range (gitleaks-action v2 default). Historical scan already run locally: **0 leaks in 120 commits**.

## Mirrors
Same setup as FactBench/titan-network and FactBench/sonrank-site.

## Next step (after merge)
Mark `gitleaks` as a required status check in branch protection for main.

## Test plan
- [x] Local historical scan: 0 leaks
- [x] Pinned to v2.3.9
- [ ] First CI run on this PR passes